### PR TITLE
docs(api): add `OpenAPI` documentation for `Cart` and `Product` endpoints

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,17 +54,23 @@
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-starter-openfeign</artifactId>
+			<version>4.2.2</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+			<version>2.8.9</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
 		</dependency>
 
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
 			<optional>true</optional>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-test</artifactId>
-			<scope>test</scope>
 		</dependency>
 	</dependencies>
 	<dependencyManagement>

--- a/src/main/java/br/com/expresscart/controller/CartController.java
+++ b/src/main/java/br/com/expresscart/controller/CartController.java
@@ -1,9 +1,11 @@
 package br.com.expresscart.controller;
 
+import br.com.expresscart.controller.api.docs.CartApi;
 import br.com.expresscart.controller.request.CartRequest;
 import br.com.expresscart.controller.request.PaymentRequest;
 import br.com.expresscart.entity.Cart;
 import br.com.expresscart.service.CartService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -12,12 +14,12 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping("/api/v1/cart")
 @RequiredArgsConstructor
-public class CartController {
+public class CartController implements CartApi {
 
     private final CartService cartService;
 
     @PostMapping
-    public ResponseEntity<Cart> createCart(@RequestBody CartRequest request) {
+    public ResponseEntity<Cart> createCart(@RequestBody @Valid CartRequest request) {
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(cartService.createCart(request));
     }

--- a/src/main/java/br/com/expresscart/controller/ProductController.java
+++ b/src/main/java/br/com/expresscart/controller/ProductController.java
@@ -1,6 +1,7 @@
 package br.com.expresscart.controller;
 
 import br.com.expresscart.client.response.PlatziProductResponse;
+import br.com.expresscart.controller.api.docs.ProductApi;
 import br.com.expresscart.service.ProductService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -14,7 +15,7 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/v1/product")
 @RequiredArgsConstructor
-public class ProductController {
+public class ProductController implements ProductApi {
 
     private final ProductService productService;
 

--- a/src/main/java/br/com/expresscart/controller/api/docs/CartApi.java
+++ b/src/main/java/br/com/expresscart/controller/api/docs/CartApi.java
@@ -36,7 +36,8 @@ public interface CartApi {
             ),
             @ApiResponse(responseCode = "400", description = "Corpo da requisição inválido", content = @Content),
             @ApiResponse(responseCode = "400", description = "Já existe um Carrinho aberto para o cliente informado", content = @Content),
-            @ApiResponse(responseCode = "404", description = "Produto não encontrado (client error)", content = @Content)
+            @ApiResponse(responseCode = "404", description = "Produto não encontrado (client error)", content = @Content),
+            @ApiResponse(responseCode = "500", description = "Erro interno da aplicação", content = @Content)
     })
     ResponseEntity<Cart> createCart(
       @RequestBody(
@@ -62,7 +63,8 @@ public interface CartApi {
                             schema = @Schema(implementation = Cart.class) // TODO: criar Response DTO para carrinho
                     )
             ),
-            @ApiResponse(responseCode = "404", description = "Carrinho não encontrado", content = @Content)
+            @ApiResponse(responseCode = "404", description = "Carrinho não encontrado", content = @Content),
+            @ApiResponse(responseCode = "500", description = "Erro interno da aplicação", content = @Content)
     })
     ResponseEntity<Cart> getCartById(
             @Parameter(in = ParameterIn.PATH, description = "ID do Carrinho", required = true)
@@ -85,7 +87,8 @@ public interface CartApi {
             ),
             @ApiResponse(responseCode = "400", description = "Corpo da requisição inválido", content = @Content),
             @ApiResponse(responseCode = "400", description = "Já existe um Carrinho aberto para o cliente informado", content = @Content),
-            @ApiResponse(responseCode = "404", description = "Produto não encontrado (client error)", content = @Content)
+            @ApiResponse(responseCode = "404", description = "Produto não encontrado (client error)", content = @Content),
+            @ApiResponse(responseCode = "500", description = "Erro interno da aplicação", content = @Content)
     })
     ResponseEntity<Cart> updateCart(
             @Parameter(in = ParameterIn.PATH, description = "ID do Carrinho", required = true)
@@ -114,7 +117,8 @@ public interface CartApi {
                     )
             ),
             @ApiResponse(responseCode = "400", description = "Operação cancelada. O carrinho informado já foi pago.", content = @Content),
-            @ApiResponse(responseCode = "404", description = "Carrinho não encontrado", content = @Content)
+            @ApiResponse(responseCode = "404", description = "Carrinho não encontrado", content = @Content),
+            @ApiResponse(responseCode = "500", description = "Erro interno da aplicação", content = @Content)
     })
     ResponseEntity<Cart> payCart(
             @Parameter(in = ParameterIn.PATH, description = "ID do Carrinho", required = true)
@@ -136,7 +140,8 @@ public interface CartApi {
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "Carrinho limpo", content = @Content),
             @ApiResponse(responseCode = "400", description = "Não é possível limpar um carrinho já vendido.", content = @Content),
-            @ApiResponse(responseCode = "404", description = "Carrinho não encontrado", content = @Content)
+            @ApiResponse(responseCode = "404", description = "Carrinho não encontrado", content = @Content),
+            @ApiResponse(responseCode = "500", description = "Erro interno da aplicação", content = @Content)
     })
     ResponseEntity<Cart> clearCart(
             @Parameter(in = ParameterIn.PATH, description = "ID do Carrinho", required = true)

--- a/src/main/java/br/com/expresscart/controller/api/docs/CartApi.java
+++ b/src/main/java/br/com/expresscart/controller/api/docs/CartApi.java
@@ -1,0 +1,145 @@
+package br.com.expresscart.controller.api.docs;
+
+import br.com.expresscart.controller.request.CartRequest;
+import br.com.expresscart.controller.request.PaymentRequest;
+import br.com.expresscart.entity.Cart;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@Tag(
+        name = "Carrinho",
+        description = "Operações para gerenciar o carrinho de compras"
+)
+public interface CartApi {
+
+    @Operation(
+            summary = "Criar novo Carrinho",
+            description = "Rota para criar um novo Carrinho com produtos"
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "201",
+                    description = "Carrinho criado com sucesso",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = Cart.class) // TODO: criar Response DTO para carrinho
+                    )
+            ),
+            @ApiResponse(responseCode = "400", description = "Corpo da requisição inválido", content = @Content),
+            @ApiResponse(responseCode = "400", description = "Já existe um Carrinho aberto para o cliente informado", content = @Content),
+            @ApiResponse(responseCode = "404", description = "Produto não encontrado (client error)", content = @Content)
+    })
+    ResponseEntity<Cart> createCart(
+      @RequestBody(
+              description = "Requisição para criar novo carrinho",
+              required = true,
+              content = @Content(
+                      schema = @Schema(implementation = CartRequest.class)
+              )
+      )
+      CartRequest request
+    );
+
+    @Operation(
+            summary = "Buscar carrinho por ID",
+            description = "Rota para mostrar os dados de um Carrinho"
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Dados do Carrinho",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = Cart.class) // TODO: criar Response DTO para carrinho
+                    )
+            ),
+            @ApiResponse(responseCode = "404", description = "Carrinho não encontrado", content = @Content)
+    })
+    ResponseEntity<Cart> getCartById(
+            @Parameter(in = ParameterIn.PATH, description = "ID do Carrinho", required = true)
+            @PathVariable String id
+    );
+
+    // TODO: criar Response DTO para atualizar carrinho, alterando apenas os itens do carrinho
+    @Operation(
+            summary = "Atualizar um Carrinho",
+            description = "Rota para atualizar um Carrinho, adicionando ou removendo produtos"
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Carrinho atualizado com sucesso",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = Cart.class)
+                    )
+            ),
+            @ApiResponse(responseCode = "400", description = "Corpo da requisição inválido", content = @Content),
+            @ApiResponse(responseCode = "400", description = "Já existe um Carrinho aberto para o cliente informado", content = @Content),
+            @ApiResponse(responseCode = "404", description = "Produto não encontrado (client error)", content = @Content)
+    })
+    ResponseEntity<Cart> updateCart(
+            @Parameter(in = ParameterIn.PATH, description = "ID do Carrinho", required = true)
+            @PathVariable String id,
+            @RequestBody(
+                    description = "Requisição para atualizar um carrinho",
+                    required = true,
+                    content = @Content(
+                            schema = @Schema(implementation = CartRequest.class)
+                    )
+            )
+            CartRequest request
+    );
+
+    @Operation(
+            summary = "Pagar carrinho por ID",
+            description = "Rota para realizar o pagamento de um carrinho"
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Dados do Carrinho",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = Cart.class) // TODO: criar Response DTO para carrinho
+                    )
+            ),
+            @ApiResponse(responseCode = "400", description = "Operação cancelada. O carrinho informado já foi pago.", content = @Content),
+            @ApiResponse(responseCode = "404", description = "Carrinho não encontrado", content = @Content)
+    })
+    ResponseEntity<Cart> payCart(
+            @Parameter(in = ParameterIn.PATH, description = "ID do Carrinho", required = true)
+            @PathVariable String id,
+            @RequestBody(
+                    description = "Requisição para pagar um carrinho",
+                    required = true,
+                    content = @Content(
+                            schema = @Schema(implementation = PaymentRequest.class)
+                    )
+            )
+            PaymentRequest request
+    );
+
+    @Operation(
+            summary = "Limpar Carrinho por ID",
+            description = "Rota para limpar os items adicionados ao Carrinho"
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Carrinho limpo", content = @Content),
+            @ApiResponse(responseCode = "400", description = "Não é possível limpar um carrinho já vendido.", content = @Content),
+            @ApiResponse(responseCode = "404", description = "Carrinho não encontrado", content = @Content)
+    })
+    ResponseEntity<Cart> clearCart(
+            @Parameter(in = ParameterIn.PATH, description = "ID do Carrinho", required = true)
+            @PathVariable String id
+    );
+}

--- a/src/main/java/br/com/expresscart/controller/api/docs/ProductApi.java
+++ b/src/main/java/br/com/expresscart/controller/api/docs/ProductApi.java
@@ -1,0 +1,62 @@
+package br.com.expresscart.controller.api.docs;
+
+import br.com.expresscart.client.response.PlatziProductResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+
+import java.util.List;
+
+@Tag(
+        name = "Produto",
+        description = "Operações para listar os produtos da API externa"
+)
+public interface ProductApi {
+
+    @Operation(
+            summary = "Buscar produtos da API externa",
+            description = "Rota para listar produtos da API externa e salvar em cache (Redis)"
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Lista de produtos retornada com sucesso",
+                    content = @Content(
+                            mediaType = "application/json",
+                            array = @ArraySchema (
+                                schema = @Schema(implementation = PlatziProductResponse.class)
+                            )
+                    )
+            ),
+            @ApiResponse(responseCode = "500", description = "Erro interno da aplicação", content = @Content)
+    })
+    ResponseEntity<List<PlatziProductResponse>> getAllProducts();
+
+    @Operation(
+            summary = "Buscar produto por ID",
+            description = "Rota para buscar produto por ID do cache (Redis)"
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Produto retornado com sucesso",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = PlatziProductResponse.class)
+                    )
+            ),
+            @ApiResponse(responseCode = "404", description = "Produto não encontrado", content = @Content)
+    })
+    ResponseEntity<PlatziProductResponse> getProductById(
+            @Parameter(in = ParameterIn.PATH, description = "ID do Produto", required = true)
+            @PathVariable Long id
+    );
+}

--- a/src/main/java/br/com/expresscart/controller/api/docs/ProductApi.java
+++ b/src/main/java/br/com/expresscart/controller/api/docs/ProductApi.java
@@ -53,7 +53,8 @@ public interface ProductApi {
                             schema = @Schema(implementation = PlatziProductResponse.class)
                     )
             ),
-            @ApiResponse(responseCode = "404", description = "Produto não encontrado", content = @Content)
+            @ApiResponse(responseCode = "404", description = "Produto não encontrado", content = @Content),
+            @ApiResponse(responseCode = "500", description = "Erro interno da aplicação", content = @Content)
     })
     ResponseEntity<PlatziProductResponse> getProductById(
             @Parameter(in = ParameterIn.PATH, description = "ID do Produto", required = true)


### PR DESCRIPTION
### This PR introduces API documentation using Springdoc OpenAPI.

It includes annotations and interfaces to improve the visibility and standardization of Cart and Product endpoints.

### Changes

- Added springdoc-openapi-starter-webmvc-ui dependency to enable Swagger UI 
- Implemented CartApi and annotated CartController with OpenAPI docs
- Implemented ProductApi and annotated ProductController with OpenAPI docs
- Added ApiResponse for 500 Internal Server Error status code

### Motivation

With these changes, the API is now self-documented and can be easily explored via Swagger UI, improving developer experience and integration with external systems.