### PR TITLE
docs: add API response examples and error schema annotations

### DIFF
--- a/src/main/java/br/com/expresscart/controller/api/docs/CartApi.java
+++ b/src/main/java/br/com/expresscart/controller/api/docs/CartApi.java
@@ -3,10 +3,13 @@ package br.com.expresscart.controller.api.docs;
 import br.com.expresscart.controller.request.CartRequest;
 import br.com.expresscart.controller.request.PaymentRequest;
 import br.com.expresscart.entity.Cart;
+import br.com.expresscart.exception.response.GenericErrorResponse;
+import br.com.expresscart.exception.response.ValidationErrorResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -18,6 +21,22 @@ import org.springframework.web.bind.annotation.PathVariable;
 @Tag(
         name = "Carrinho",
         description = "Operações para gerenciar o carrinho de compras"
+)
+@ApiResponse(responseCode = "500", description = "Erro interno da aplicação",
+        content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = GenericErrorResponse.class),
+                examples = @ExampleObject(
+                    name = "Erro Interno",
+                    value = """
+                        {
+                          "timestamp": "2025-08-27T01:50:59.386Z",
+                          "status": 500,
+                          "message": "Erro interno da aplicação"
+                        }
+                    """
+                )
+        )
 )
 public interface CartApi {
 
@@ -34,17 +53,72 @@ public interface CartApi {
                             schema = @Schema(implementation = Cart.class) // TODO: criar Response DTO para carrinho
                     )
             ),
-            @ApiResponse(responseCode = "400", description = "Corpo da requisição inválido", content = @Content),
-            @ApiResponse(responseCode = "400", description = "Já existe um Carrinho aberto para o cliente informado", content = @Content),
-            @ApiResponse(responseCode = "404", description = "Produto não encontrado (client error)", content = @Content),
-            @ApiResponse(responseCode = "500", description = "Erro interno da aplicação", content = @Content)
+            @ApiResponse(responseCode = "400", description = "Carrinho Duplicado / Erro de Validação",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(
+                                    oneOf = {GenericErrorResponse.class, ValidationErrorResponse.class}
+                            ),
+                            examples = {
+                                    @ExampleObject(
+                                        name = "Carrinho duplicado",
+                                        value = """
+                                            {
+                                              "timestamp": "2025-08-27T01:50:59.386Z",
+                                              "status": 400,
+                                              "message": "Já existe um Carrinho aberto para o cliente informado"
+                                            }
+                                        """
+                                    ),
+                                    @ExampleObject(
+                                        name = "Erro de validação",
+                                        value = """
+                                            {
+                                              "field": "email",
+                                              "message": "O campo email deve ser um endereço válido"
+                                            }
+                                        """
+                                    )
+                            }
+                    )
+            ),
+            @ApiResponse(responseCode = "404", description = "Produto não encontrado (Platzi Client)",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = GenericErrorResponse.class),
+                            examples = @ExampleObject(
+                                name = "Produto não encontrado",
+                                value = """
+                                    {
+                                      "timestamp": "2025-08-27T01:50:59.386Z",
+                                      "status": 404,
+                                      "message": "Produto não encontrado (Platzi Client)"
+                                    }
+                                """
+                            )
+                    )
+            )
     })
     ResponseEntity<Cart> createCart(
       @RequestBody(
               description = "Requisição para criar novo carrinho",
               required = true,
               content = @Content(
-                      schema = @Schema(implementation = CartRequest.class)
+                      schema = @Schema(implementation = CartRequest.class),
+                      examples = @ExampleObject(
+                          name = "Criar Carrinho",
+                          value = """
+                              {
+                                  "clientId": "1",
+                                  "products": [
+                                    {
+                                      "id": 1,
+                                      "quantity": 1
+                                    }
+                                  ]
+                              }
+                          """
+                      )
               )
       )
       CartRequest request
@@ -63,8 +137,22 @@ public interface CartApi {
                             schema = @Schema(implementation = Cart.class) // TODO: criar Response DTO para carrinho
                     )
             ),
-            @ApiResponse(responseCode = "404", description = "Carrinho não encontrado", content = @Content),
-            @ApiResponse(responseCode = "500", description = "Erro interno da aplicação", content = @Content)
+            @ApiResponse(responseCode = "404", description = "Carrinho não encontrado",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = GenericErrorResponse.class),
+                            examples = @ExampleObject(
+                                name = "Carrinho não encontrado",
+                                value = """
+                                    {
+                                      "timestamp": "2025-08-27T11:08:27.627557053",
+                                      "status": 404,
+                                      "message": "Carrinho não encontrado."
+                                    }
+                                """
+                            )
+                    )
+            )
     })
     ResponseEntity<Cart> getCartById(
             @Parameter(in = ParameterIn.PATH, description = "ID do Carrinho", required = true)
@@ -83,12 +171,54 @@ public interface CartApi {
                     content = @Content(
                             mediaType = "application/json",
                             schema = @Schema(implementation = Cart.class)
+                            // TODO: adicionar example após criar o Response DTO
                     )
             ),
-            @ApiResponse(responseCode = "400", description = "Corpo da requisição inválido", content = @Content),
-            @ApiResponse(responseCode = "400", description = "Já existe um Carrinho aberto para o cliente informado", content = @Content),
-            @ApiResponse(responseCode = "404", description = "Produto não encontrado (client error)", content = @Content),
-            @ApiResponse(responseCode = "500", description = "Erro interno da aplicação", content = @Content)
+            @ApiResponse(responseCode = "400", description = "Carrinho Duplicado / Erro de Validação",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(
+                                    oneOf = {GenericErrorResponse.class, ValidationErrorResponse.class}
+                            ),
+                            examples = {
+                                    @ExampleObject(
+                                        name = "Carrinho duplicado",
+                                        value = """
+                                            {
+                                              "timestamp": "2025-08-27T01:50:59.386Z",
+                                              "status": 400,
+                                              "message": "Já existe um Carrinho aberto para o cliente informado"
+                                            }
+                                        """
+                                    ),
+                                    @ExampleObject(
+                                        name = "Erro de validação",
+                                        value = """
+                                            {
+                                              "field": "email",
+                                              "message": "O campo email deve ser um endereço válido"
+                                            }
+                                        """
+                                    )
+                            }
+                    )
+            ),
+            @ApiResponse(responseCode = "404", description = "Produto não encontrado (Platzi Client)",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = GenericErrorResponse.class),
+                            examples = @ExampleObject(
+                                name = "Produto não encontrado",
+                                value = """
+                                    {
+                                      "timestamp": "2025-08-27T01:50:59.386Z",
+                                      "status": 404,
+                                      "message": "Produto não encontrado (Platzi Client)"
+                                    }
+                                """
+                            )
+                    )
+            )
     })
     ResponseEntity<Cart> updateCart(
             @Parameter(in = ParameterIn.PATH, description = "ID do Carrinho", required = true)
@@ -97,7 +227,21 @@ public interface CartApi {
                     description = "Requisição para atualizar um carrinho",
                     required = true,
                     content = @Content(
-                            schema = @Schema(implementation = CartRequest.class)
+                            schema = @Schema(implementation = CartRequest.class),
+                            examples = @ExampleObject(
+                                name = "Atualizar Carrinho",
+                                value = """
+                                    {
+                                      "clientId": "1",
+                                      "products": [
+                                        {
+                                          "id": 1,
+                                          "quantity": 1
+                                        }
+                                      ]
+                                    }
+                                """
+                            )
                     )
             )
             CartRequest request
@@ -116,9 +260,38 @@ public interface CartApi {
                             schema = @Schema(implementation = Cart.class) // TODO: criar Response DTO para carrinho
                     )
             ),
-            @ApiResponse(responseCode = "400", description = "Operação cancelada. O carrinho informado já foi pago.", content = @Content),
-            @ApiResponse(responseCode = "404", description = "Carrinho não encontrado", content = @Content),
-            @ApiResponse(responseCode = "500", description = "Erro interno da aplicação", content = @Content)
+            @ApiResponse(responseCode = "400", description = "Operação cancelada. O carrinho informado já foi pago.",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = GenericErrorResponse.class),
+                            examples = @ExampleObject(
+                                name = "Pagar Carrinho vendido",
+                                value = """
+                                    {
+                                      "timestamp": "2025-08-27T11:08:27.627557053",
+                                      "status": 400,
+                                      "message": "Operação cancelada. O carrinho informado já foi pago."
+                                    }
+                                """
+                            )
+                    )
+            ),
+            @ApiResponse(responseCode = "404", description = "Carrinho não encontrado",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = GenericErrorResponse.class),
+                            examples = @ExampleObject(
+                                name = "Carrinho não encontrado",
+                                value = """
+                                    {
+                                      "timestamp": "2025-08-27T11:08:27.627557053",
+                                      "status": 404,
+                                      "message": "Carrinho não encontrado."
+                                    }
+                                """
+                            )
+                    )
+            )
     })
     ResponseEntity<Cart> payCart(
             @Parameter(in = ParameterIn.PATH, description = "ID do Carrinho", required = true)
@@ -139,9 +312,38 @@ public interface CartApi {
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "Carrinho limpo", content = @Content),
-            @ApiResponse(responseCode = "400", description = "Não é possível limpar um carrinho já vendido.", content = @Content),
-            @ApiResponse(responseCode = "404", description = "Carrinho não encontrado", content = @Content),
-            @ApiResponse(responseCode = "500", description = "Erro interno da aplicação", content = @Content)
+            @ApiResponse(responseCode = "400", description = "Não é possível limpar um carrinho já vendido.",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = GenericErrorResponse.class),
+                            examples = @ExampleObject(
+                                name = "Limpar Carrinho vendido",
+                                value = """
+                                    {
+                                      "timestamp": "2025-08-27T11:08:27.627557053",
+                                      "status": 400,
+                                      "message": "Não é possível limpar um carrinho já vendido."
+                                    }
+                                """
+                            )
+                    )
+            ),
+            @ApiResponse(responseCode = "404", description = "Carrinho não encontrado",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = GenericErrorResponse.class),
+                            examples = @ExampleObject(
+                                name = "Carrinho não encontrado",
+                                value = """
+                                    {
+                                      "timestamp": "2025-08-27T11:08:27.627557053",
+                                      "status": 404,
+                                      "message": "Carrinho não encontrado."
+                                    }
+                                """
+                            )
+                    )
+            )
     })
     ResponseEntity<Cart> clearCart(
             @Parameter(in = ParameterIn.PATH, description = "ID do Carrinho", required = true)

--- a/src/main/java/br/com/expresscart/controller/api/docs/ProductApi.java
+++ b/src/main/java/br/com/expresscart/controller/api/docs/ProductApi.java
@@ -1,11 +1,13 @@
 package br.com.expresscart.controller.api.docs;
 
 import br.com.expresscart.client.response.PlatziProductResponse;
+import br.com.expresscart.exception.response.GenericErrorResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -18,6 +20,23 @@ import java.util.List;
 @Tag(
         name = "Produto",
         description = "Operações para listar os produtos da API externa"
+)
+@ApiResponse(responseCode = "500", description = "Erro interno da aplicação",
+        content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = GenericErrorResponse.class),
+                examples = @ExampleObject(
+                    name = "Erro Interno",
+                    value = """
+                        {
+                          "timestamp": "2025-08-27T01:50:59.386Z",
+                          "status": 500,
+                          "message": "Erro interno da aplicação"
+                        }
+                    """
+                )
+
+        )
 )
 public interface ProductApi {
 
@@ -33,10 +52,29 @@ public interface ProductApi {
                             mediaType = "application/json",
                             array = @ArraySchema (
                                 schema = @Schema(implementation = PlatziProductResponse.class)
+                            ),
+                            examples = @ExampleObject(
+                                name = "Lista de Produtos",
+                                value = """
+                                    [
+                                      {
+                                        "id": 103,
+                                        "title": "Demo Product",
+                                        "price": 10,
+                                        "images": [
+                                          "https://placehold.co/600x400"
+                                        ],
+                                        "category": {
+                                          "id": 1,
+                                          "name": "Demo Category",
+                                          "image": "https://placeimg.com/640/480/any"
+                                        }
+                                      }
+                                    ]
+                                """
                             )
                     )
-            ),
-            @ApiResponse(responseCode = "500", description = "Erro interno da aplicação", content = @Content)
+            )
     })
     ResponseEntity<List<PlatziProductResponse>> getAllProducts();
 
@@ -50,11 +88,43 @@ public interface ProductApi {
                     description = "Produto retornado com sucesso",
                     content = @Content(
                             mediaType = "application/json",
-                            schema = @Schema(implementation = PlatziProductResponse.class)
+                            schema = @Schema(implementation = PlatziProductResponse.class),
+                            examples = @ExampleObject(
+                                name = "Dados do Produto",
+                                value = """
+                                  {
+                                    "id": 103,
+                                    "title": "Demo Product",
+                                    "price": 10,
+                                    "images": [
+                                      "https://placehold.co/600x400"
+                                    ],
+                                    "category": {
+                                      "id": 1,
+                                      "name": "Demo Category",
+                                      "image": "https://placeimg.com/640/480/any"
+                                    }
+                                  }
+                                """
+                            )
                     )
             ),
-            @ApiResponse(responseCode = "404", description = "Produto não encontrado", content = @Content),
-            @ApiResponse(responseCode = "500", description = "Erro interno da aplicação", content = @Content)
+            @ApiResponse(responseCode = "404", description = "Produto não encontrado",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = GenericErrorResponse.class),
+                            examples = @ExampleObject(
+                                name = "Produto não encontrado",
+                                value = """
+                                    {
+                                      "timestamp": "2025-08-27T01:50:59.386Z",
+                                      "status": 404,
+                                      "message": "Produto não encontrado (Platzi Client)"
+                                    }
+                                """
+                            )
+                    )
+            )
     })
     ResponseEntity<PlatziProductResponse> getProductById(
             @Parameter(in = ParameterIn.PATH, description = "ID do Produto", required = true)

--- a/src/main/java/br/com/expresscart/exception/response/GenericErrorResponse.java
+++ b/src/main/java/br/com/expresscart/exception/response/GenericErrorResponse.java
@@ -1,10 +1,17 @@
 package br.com.expresscart.exception.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.time.LocalDateTime;
 
 public record GenericErrorResponse(
+        @Schema(description = "Momento em que o erro ocorreu")
         LocalDateTime timestamp,
+
+        @Schema(description = "Código HTTP retornado")
         int status,
+
+        @Schema(description = "Mensagem descritiva do erro")
         String message
 ) {
 }

--- a/src/main/java/br/com/expresscart/exception/response/ValidationErrorResponse.java
+++ b/src/main/java/br/com/expresscart/exception/response/ValidationErrorResponse.java
@@ -1,8 +1,15 @@
 package br.com.expresscart.exception.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.springframework.validation.FieldError;
 
-public record ValidationErrorResponse(String field, String message) {
+public record ValidationErrorResponse(
+        @Schema(description = "Campo que falhou na validação")
+        String field,
+
+        @Schema(description = "Mensagem de erro da validação")
+        String message
+) {
     public ValidationErrorResponse(FieldError fieldError) {
         this(
                 fieldError.getField(),


### PR DESCRIPTION
### Overview
This PR improves the API documentation by adding response examples and enhancing error response schemas.

### Changes
- Added response examples to ProductApi endpoints
- Added response examples to CartApi endpoints
- Annotated GenericErrorResponse and ValidationErrorResponse with @Schema for better schema generation

### Motivation
These changes improve API clarity and make the generated documentation more useful for developers consuming the service.

### Checklist
- [x] Response examples reviewed
- [x] Schema annotations validated
- [x] Swagger UI reflects updated examples and schemas
